### PR TITLE
【bugfix】在markdown格式下,body字符串带有html标签,如<a>,需要去除

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -133,6 +133,7 @@ module.exports = (opts, ctx) => {
               : false
           if (useMarkdown || data.format === 'markdown') {
             postContent = data.body || ''
+            postContent = postContent.replace(/<[^>]+>/g,"")
           } else {
             postContent = prettify(data.body_html || '')
           }


### PR DESCRIPTION
语雀设置source=markdown时；文档可能含有html标签；